### PR TITLE
Use Java 17 and Java 21 in the Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,10 @@
-buildPlugin()
-
+/*
+ See the documentation for more options:
+ https://github.com/jenkins-infra/pipeline-library/
+*/
+buildPlugin(
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  configurations: [
+    [platform: 'linux', jdk: 21],
+    [platform: 'windows', jdk: 17],
+])


### PR DESCRIPTION
## Use Java 17 and Java 21 in the Jenkinsfile

Java 8 is not supported by Jenkins 2.440.3 so the build fails on ci.jenkins.io

I used the [improve a plugin tutorial](https://www.jenkins.io/doc/developer/tutorial-improve/add-a-jenkinsfile/) as the basis for this pull request

### Testing done

Confirmed that tests pass on my Java 21 Linux computer.  Will rely on ci.jenkins.io to test Windows with Java 17

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
