### PR TITLE
Use parent pom 4.88

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.86</version>
+    <version>4.88</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
## Use parent pom 4.88

This is the last parent pom before the 5.0 upgrade to require Java 17, Spring Security 6, Eclipse Jetty 12, and Jakarta EE 9.  Use that version to have the latest tooling for plugins that still support Java 11.

Needs:

* https://github.com/jenkinsci/openedge-plugin/pull/7

### Testing done

Confirmed that automated tests pass.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
