### PR TITLE
Migrate documentation to GitHub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Version history
+
+## Version 0.23 (September 24, 2024)
+
+* Fix merge accident
+
+## Version 0.22 (September 24, 2024)
+
+* Remove `withOpenEdge` symbol
+
+## Version 0.9 (June 6th, 2019)
+
+* Just code cleanup
+
+## Version 0.8 (June 6th, 2019)
+
+* First release available in update center
+
+## Version 0.5 (circa 2014)
+
+* Initial release

--- a/README.md
+++ b/README.md
@@ -1,3 +1,41 @@
 # OpenEdge Plugin for Jenkins
 
 This plugin lets you manage OpenEdge installations across different agents. Once installed, you can add OpenEdge installations on the main Jenkins configuration page.
+
+Configure [OpenEdge ABL](https://www.progress.com/openedge) tools location on Jenkins nodes.
+
+## What it does
+
+During a build, this plugin will:
+
+* Export the DLC environment variable, pointing to the installed OpenEdge tool
+* Add the path $DLC/bin to the PATH, so that the tools are available during the build
+
+## Setup
+
+### Global configuration
+
+1. In the tools settings (Manage Jenkins -> Global Tool Configuration), find the "OpenEdge Installations" section and click "Add OpenEdge".
+2. Enter a name, e.g. "OpenEdge 12.0" - the name itself has no significance, but will be displayed to users during job configuration
+3. Type the installation directory (or leave it blank if OpenEdge is not installed on the master server)
+
+### Node configuration
+
+1. In the node settings (select node -> Configuration), check "Tools location" (if unchecked)
+2. Each OpenEdge installation configured globally can be overridden in the slave
+
+## Per-job configuration
+
+### Freestyle
+
+1. In a job's configuration, find the "Build environment" section
+2. Select the "Set up OpenEdge" checkbox
+3. Select the OpenEdge version you want to use when this job is built
+
+### Pipeline
+
+As with any other type of Tool Installer, you can use the tool step to inject the DLC variable.
+
+## Version history
+
+Refer to the [changelog](CHANGELOG.md) for version history.

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <packaging>hpi</packaging>
   <name>OpenEdge (Progress ABL)</name>
   <version>0.23</version>
-  <url>https://wiki.jenkins.io/display/JENKINS/OpenEdge+Plugin</url>
+  <url>https://github.com/jenkinsci/openedge-plugin</url>
 
   <licenses>
     <license>


### PR DESCRIPTION
## Migrate documentation to GitHub

It is easier to maintain the documentation if it is stored in the GitHub README file.  Next plugin release after this is merged will include the documentation in the [official plugin page](https://plugins.jenkins.io/openedge/) and will remove the warning that says:

> This content is served from the Jenkins Wiki Export which is now permanently offline and before that a read-only state. We would love your help in moving plugin documentation to GitHub, see the guidelines.

Will improve the [plugin health score](https://plugins.jenkins.io/openedge/healthscore/).

The [tutorial](https://www.jenkins.io/doc/developer/tutorial-improve/migrate-documentation-to-github/) was used to create this pull request.

Extracted the changelog for the most recent releases by reading the git history.

Needs:

* https://github.com/jenkinsci/openedge-plugin/pull/7

### Testing done

COnfirmed that automated tests pass.  Will rely on GitHub rendering of README to check it looks correct.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
